### PR TITLE
⚡️ Destination 컬럼명 패칭

### DIFF
--- a/src/components/plan/Destination.jsx
+++ b/src/components/plan/Destination.jsx
@@ -192,7 +192,7 @@ function Destination() {
                       <img
                         className="h-full w-full object-cover"
                         src={
-                          dest.imageUrl ||
+                          dest.imgUrl ||
                           `https://loremflickr.com/100/100?random=${5 * idx}`
                         }
                         alt={dest.name}


### PR DESCRIPTION
imageUrl -> imgUrl로 변경
(backend-legacy -> backend 다시 클론 받으며 생긴 컬럼명 패칭)
## #️⃣ 이슈 번호
- close #37 

## 📝 작업 내용
imageUrl -> imgUrl로 변경

## 📸 스크린샷 (선택)
<img width="517" alt="스크린샷 2025-05-18 오후 10 23 39" src="https://github.com/user-attachments/assets/69649fce-b3c2-4748-8b7b-64adec1023f2" />


## 💬 리뷰 요구사항 (선택)


## ✅ 체크리스트
- [o] 코드가 정상적으로 컴파일되나요?
- [o] lint 적용을 하였나요?
- [o] 테스트 코드를 통과했나요?
- [o] merge할 브랜치의 위치를 확인했나요?

## 🔔 ETC.
